### PR TITLE
Showing user growth chart of last 30 days on /analytics

### DIFF
--- a/app/assets/javascripts/user/application.js
+++ b/app/assets/javascripts/user/application.js
@@ -11,6 +11,7 @@
 // about supported directives.
 //
 //= require rails-ujs
+//= require highcharts
 //= require popper
 //= require bootstrap.min
 //= require bootstrap-sprockets

--- a/app/assets/javascripts/user/highcharts_user_growth_chart.js
+++ b/app/assets/javascripts/user/highcharts_user_growth_chart.js
@@ -1,0 +1,58 @@
+var date = new Date();
+var firstDayOfMonth = Date.UTC(date.getFullYear(), date.getMonth(), 1);
+
+function userGrowthChart (data) {
+  Highcharts.chart('user-growth', {
+    title: {
+      text: ''
+    },
+    xAxis: {
+      type: 'datetime'
+    },
+    yAxis: {
+      title: {
+	text: 'Users'
+      },
+      min: 0
+    },
+    legend: {
+      layout: 'vertical',
+      align: 'right',
+      verticalAlign: 'middle'
+    },
+    plotOptions: {
+      series: {
+	showInLegend: false,
+	label: {
+	  connectorAllowed: false
+	}
+      }
+    },
+    series: data,
+    responsive: {
+      rules: [{
+	condition: {
+	  maxWidth: 500
+	},
+	chartOptions: {
+	  legend: {
+	    layout: 'horizontal',
+	    align: 'center',
+	    verticalAlign: 'bottom'
+	  }
+	}
+      }]
+    }
+  });
+}
+$(document).ready(function() {
+  $.ajax({
+    url: '/user_growth_json_data',
+    type: 'GET',
+    async: true,
+    dataType: "json",
+    success: function (data) {
+      userGrowthChart(data);
+    }
+  });
+});

--- a/app/controllers/analytics_controller.rb
+++ b/app/controllers/analytics_controller.rb
@@ -1,14 +1,20 @@
 class AnalyticsController < ApplicationController
-	before_action :authenticate_user!
-	layout 'user'
+  before_action :authenticate_user!
+  layout 'user'
 
   def index
+    @data = Stat.all
+  end
 
+  def user_growth_json_data
+    Stat.fetch_and_update
+    render json: [{
+      data: Stat.growth_chart_data
+    }]
+  end
 
-	end
-	
-	def logs
-		@authentication_logs = []
-	end
+  def logs
+    @authentication_logs = []
+  end
 
 end

--- a/app/models/app.rb
+++ b/app/models/app.rb
@@ -1,5 +1,7 @@
 class App < ApplicationRecord
   belongs_to :user, optional: true
+  has_many :stats
+
   validates_url :openid_redirect_urls, message: "- please include http or https in the URL"
   validates_url :client_uri, message: "- please include http or https in the URL"
   validates_url :policy_uri, message: "- please include http or https in the URL"

--- a/app/models/stat.rb
+++ b/app/models/stat.rb
@@ -1,0 +1,38 @@
+class Stat < ApplicationRecord
+  belongs_to :app
+
+  scope :last_thirty_days, -> { where("period_starting > ?", 30.days.ago) }
+
+  def self.fetch_and_update
+    fetch and update
+  end
+
+  def self.fetch interval="month"
+    auth = {
+      username: ENV['QRYPTO_USERNAME'],
+      password: ENV['QRYPTO_PASSWORD'],
+    }
+
+    base_uri = "https://srv.qryp.to/api/logsummary/825db136-ce87-444c-8b7c-89f6b49a00eb/#{interval}"
+
+    @stats ||= HTTParty.get( base_uri, basic_auth: auth)
+  end
+
+  def self.update
+    @stats.map do |stat|
+      record = Stat.find_or_initialize_by(
+        client_id: stat['client_id'],
+      )
+      record.save!
+    end
+  end
+
+  def self.growth_chart_data
+    last_thirty_days.collect do |e|
+      [
+        e['period_starting'].utc.to_datetime.strftime("%Q").to_i,
+        e['distinct_identities']
+      ]
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -26,6 +26,7 @@ Rails.application.routes.draw do
   get '/get-started', to: 'setup#get_started', as: 'get-started'
   get '/pricing', to: 'setup#pricing', as: 'pricing'
   get '/analytics', to: 'analytics#index', as: 'analytics'
+  get '/user_growth_json_data', to: 'analytics#user_growth_json_data'
   get '/logs', to: 'analytics#logs', as: 'logs'
   get '/manage', to: 'manage#index', as: 'manage'
 

--- a/db/migrate/20180830113658_create_stats.rb
+++ b/db/migrate/20180830113658_create_stats.rb
@@ -1,0 +1,23 @@
+class CreateStats < ActiveRecord::Migration[5.1]
+  def change
+    create_table :stats do |t|
+      t.string :client_id
+      t.datetime :period_starting
+      t.string :operation_type
+      t.string :operation
+      t.string :start_result
+      t.string :finish_result
+      t.integer :operations_started
+      t.integer :operations_finished
+      t.integer :distinct_identities
+      t.integer :total_elapsed_time_minutes
+      t.integer :total_elapsed_time_seconds
+      t.integer :total_elapsed_time_miliseconds
+      t.integer :average_elapsed_time_seconds
+      t.integer :average_elapsed_time_miliseconds
+      t.references :app, index: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180816020732) do
+ActiveRecord::Schema.define(version: 20180830113658) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -66,6 +66,27 @@ ActiveRecord::Schema.define(version: 20180816020732) do
     t.datetime "updated_at", null: false
     t.index ["name", "resource_type", "resource_id"], name: "index_roles_on_name_and_resource_type_and_resource_id"
     t.index ["resource_type", "resource_id"], name: "index_roles_on_resource_type_and_resource_id"
+  end
+
+  create_table "stats", force: :cascade do |t|
+    t.string "client_id"
+    t.datetime "period_starting"
+    t.string "operation_type"
+    t.string "operation"
+    t.string "start_result"
+    t.string "finish_result"
+    t.integer "operations_started"
+    t.integer "operations_finished"
+    t.integer "distinct_identities"
+    t.integer "total_elapsed_time_minutes"
+    t.integer "total_elapsed_time_seconds"
+    t.integer "total_elapsed_time_miliseconds"
+    t.integer "average_elapsed_time_seconds"
+    t.integer "average_elapsed_time_miliseconds"
+    t.bigint "app_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["app_id"], name: "index_stats_on_app_id"
   end
 
   create_table "subscriptions", force: :cascade do |t|

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -24,3 +24,16 @@ App.create('name'=>'Acme', 'platform'=>'web', 'account_id'=>'', 'user_id'=>'3', 
 
 App.create('name'=>'Gennovacap', 'platform'=>'web', 'account_id'=>'', 'user_id'=>'4', 'openid_client_id'=>'2393bf30-75c5-42ce-8de4-5289fa87bcd3', 'openid_client_secret'=>'lsm2DC4NoKS1qBMX2s4KzYq9wlACG0rEDS5+b36g3oRvXdiFtOKgnvv2OlYezanP', 'openid_redirect_urls'=>'http://gennovacap.com/callback_url', 'openid_client_access_token'=>'', 'token_endpoint_auth_method'=>'client_secret_basic', 'logo_uri'=>'http://gennovacap.com/logo.png', 'client_uri'=>'http://gennovacap.com/', 'policy_uri'=>'http://gennovacap.com/policy', 'tos_uri'=>'http://gennovacap.com/tos', 'contacts'=>'reza@gennovacap.com')
 App.create('name'=>'Acme', 'platform'=>'web', 'account_id'=>'', 'user_id'=>'4', 'openid_client_id'=>'2393bf30-75c5-42ce-8de4-5289fa87bcd3', 'openid_client_secret'=>'lsm2DC4NoKS1qBMX2s4KzYq9wlACG0rEDS5+b36g3oRvXdiFtOKgnvv2OlYezanP', 'openid_redirect_urls'=>'http://Acme.com/callback_url', 'openid_client_access_token'=>'', 'token_endpoint_auth_method'=>'client_secret_basic', 'logo_uri'=>'http://Acme.com/logo.png', 'client_uri'=>'http://Acme.com/', 'policy_uri'=>'http://Acme.com/policy', 'tos_uri'=>'http://Acme.com/tos', 'contacts'=>'reza@Acme.com')
+
+20.times do |i|
+  begin
+    Stat.create!(
+      period_starting: i.days.ago,
+      distinct_identities: rand(1..1000),
+      app: App.first
+    )
+    print '.'
+  rescue => e
+    puts e.message
+  end
+end


### PR DESCRIPTION
### Prequisites

 - Two environment variables `QRYPTO_USERNAME` and `QRYPTO_PASSWORD` has to be defined.
 - Run the seed file. The current value on the API endpoint does not render a nice graph. So the seed for the Stat model is added.

### Note
 - The graph renders the data from the previous 30 days(from the current day) and not the previous month.
 - As mentioned in the README of the project, `App.openid_client_id` is the same as `Stat.first.client_id` so I would have established the foreign key but `openid_client_id` does not have `unique` constraint set and I am not sure if the app will work correctly if I do that. So I have not changed that.

### Demo
![image](https://user-images.githubusercontent.com/422544/44995806-66528380-afc2-11e8-915e-493ec4bffb24.png)
